### PR TITLE
Remove unconditional config requires

### DIFF
--- a/gen/generateBassLineForSong.js
+++ b/gen/generateBassLineForSong.js
@@ -3,8 +3,6 @@
 // Modificato per utilizzare section.mainChordSlots per durate accurate degli accordi,
 // per migliorare il riempimento degli slot temporali, e con log di debug aggiunti.
 
-require('../lib/config-music-data.js');
-
 if (typeof require !== 'undefined') {
     require('../lib/config-music-data.js');
 }

--- a/gen/generateBassLineForSong_v2.js
+++ b/gen/generateBassLineForSong_v2.js
@@ -1,6 +1,5 @@
 // File: gen/generateBassLineForSong_v2.js
 // CapricEngine - New Bass Line Generator - v1.0
-require('../lib/config-music-data.js');
 if (typeof require !== 'undefined') {
     require('../lib/config-music-data.js');
 }

--- a/gen/generateDrumTrackForSong.js
+++ b/gen/generateDrumTrackForSong.js
@@ -3,8 +3,6 @@
 // Versione corretta per preservare le funzioni 'apply' durante il cloning del pattern,
 // utilizzare TICKS_PER_QUARTER_NOTE_REFERENCE globale, e con log di debug migliorati.
 
-require('../lib/config-music-data.js');
-
 if (typeof require !== 'undefined') {
     require('../lib/config-music-data.js');
 }

--- a/gen/generateVocalLineForSong.js
+++ b/gen/generateVocalLineForSong.js
@@ -2,8 +2,6 @@
 // CapricEngine - Vocal Line Generator
 // Modificato per utilizzare section.mainChordSlots e senza la definizione interna di VOCAL_STYLE_PROFILES.
 
-require('../lib/config-music-data.js');
-
 if (typeof require !== 'undefined') {
     require('../lib/config-music-data.js');
 }

--- a/gen/melody-generator.js
+++ b/gen/melody-generator.js
@@ -1,8 +1,6 @@
 // File: gen/melody-generator.js
 // Genera una traccia melodica "Fake Inspiration" per la canzone.
 // Modificato per utilizzare section.mainChordSlots per durate accurate degli accordi.
-require('../lib/config-music-data.js');
-
 if (typeof require !== 'undefined') {
     require('../lib/config-music-data.js');
 }


### PR DESCRIPTION
## Summary
- remove unconditional `config-music-data.js` import from generator scripts
- keep conditional import for Node usage

## Testing
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
const files=[
'gen/melody-generator.js',
'gen/generateBassLineForSong.js',
'gen/generateBassLineForSong_v2.js',
'gen/generateVocalLineForSong.js',
'gen/generateDrumTrackForSong.js'];
for(const f of files){
  const code=fs.readFileSync(f,'utf8');
  vm.runInNewContext(code,{console});
  console.log(f+': OK');
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68743364e8188333ac6b5cce1b792109